### PR TITLE
Fix "fetch" snippet

### DIFF
--- a/src/snippets/javascript/fetch.js
+++ b/src/snippets/javascript/fetch.js
@@ -232,7 +232,7 @@ ${operationData.type} unnamed${capitalizeFirstLetter(operationData.type)}${idx +
 
     const serverComment = options.server ? getComment('nodeFetch') : '';
     const serverImport = options.server
-      ? `import fetch from 'node-fetch';\n`
+      ? `import fetch from "node-fetch";\n`
       : '';
 
     const graphqlQuery = generateDocumentQuery(operationDataList);

--- a/src/snippets/javascript/fetch.js
+++ b/src/snippets/javascript/fetch.js
@@ -122,7 +122,7 @@ function promiseFetcherInvocation(
   ).map(def => def.variable.name.value);
   const variables = Object.entries(
     namedOperationData.variables || {}
-  ).map(([key, value]) => `const ${key} = ${value};`);
+  ).map(([key, value]) => `const ${key} = ${JSON.stringify(value, null, 2)};`);
   return `${variables.join('\n')}
 
 ${operationFunctionName(namedOperationData)}(${params.join(', ')})
@@ -172,7 +172,7 @@ function asyncFetcherInvocation(
   ).map(def => def.variable.name.value);
   const variables = Object.entries(
     namedOperationData.variables || {}
-  ).map(([key, value]) => `const ${key} = ${value};`);
+  ).map(([key, value]) => `const ${key} = ${JSON.stringify(value, null, 2)};`);
   return `async function start(${params.join(', ')}) {
   const { errors, data } = await ${operationFunctionName(
     namedOperationData,


### PR DESCRIPTION
* Make JSHint happy about semicolons and etc. in generated code.
* Hide headers from generated code if headers are empty.
* Fix bug with invalid generated code (variables were connected using a space instead of a comma).
* Add variable declarations with values from the GraphiQL's "Variables" tab.
* Fix bug with variables (variables were passed to the function in quotes as strings instead of variable names without quotes).
* Pass variables to functions properly (to all functions in the chain).
* Use caret for npm package version.
* Fix the lenght of comments.