### PR TITLE
Fix "reactApollo" snippet

### DIFF
--- a/src/snippets/javascript/reactApollo.js
+++ b/src/snippets/javascript/reactApollo.js
@@ -295,7 +295,7 @@ ${addLeftWhitespace(
 
         return component;
       })
-      .join(';\n\n');
+      .join('\n\n');
 
     const componentInstantiations = operationDataList
       .map(operationData => {

--- a/src/snippets/javascript/reactApollo.js
+++ b/src/snippets/javascript/reactApollo.js
@@ -311,7 +311,7 @@ ${addLeftWhitespace(
       .map(operationData => {
         const variables = Object.entries(
           operationData.variables || {}
-        ).map(([key, value]) => `const ${key} = ${value};`);
+        ).map(([key, value]) => `const ${key} = ${JSON.stringify(value, null, 2)};`);
 
         return `${variables.join('\n')}`;
       })


### PR DESCRIPTION
* Fix bug with invalid generated code (variables were connected using a space instead of a comma).
* Fix bug with invalid generated code (props were connected using a space instead of a comma).
* Fix bug with invalid generated code (string values in headers were not in quotes and were connected using a just new line instead of a comma + new line).
* Use caret for npm package versions.
* Make JSHint happy about semicolons and etc. in generated code.
* Add variable declarations with real values from the GraphiQL's "Variables" tab.
* Fix the lenght of comments.