### PR TITLE
Add ability to generate a code sandbox from a snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,13 +108,14 @@ export default class GraphiQLWithCodeExporter extends Component {
 
 What we call **snippet** here, is actually an object with 4 required keys.
 
-| Key            | Type       | Description                                                                                                                                                       |
-| -------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| name           | _string_   | A name that is used to identify the snippet.                                                                                                                      |
-| language       | _string_   | A language string that is used to group the snippets by language.                                                                                                 |
-| codeMirrorMode | _string_   | A valid [CodeMirror mode](https://codemirror.net/mode/) used for syntax highlighting. Make sure to also require the mode (e.g. `import 'codemirror/mode/jsx/jsx'` |
-| options        | _Option[]_ | Options are rendered as checkboxes and can be used to customize snippets. They must have an unique id, a label and an initial value of either true or false.      |
-| generate       | _Function_ | A function that returns the generated code as a single string. It receives below listed data as an object.                                                        |
+| Key                      | Type       | Description                                                                                                                                                       |
+|--------------------------|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| name                     | _string_   | A name that is used to identify the snippet.                                                                                                                      |
+| language                 | _string_   | A language string that is used to group the snippets by language.                                                                                                 |
+| codeMirrorMode           | _string_   | A valid [CodeMirror mode](https://codemirror.net/mode/) used for syntax highlighting. Make sure to also require the mode (e.g. `import 'codemirror/mode/jsx/jsx'` |
+| options                  | _Option[]_ | Options are rendered as checkboxes and can be used to customize snippets. They must have an unique id, a label and an initial value of either true or false.      |
+| generate                 | _Function_ | A function that returns the generated code as a single string. It receives below listed data as an object.                                                        |
+| generateCodesandboxFiles | _Function_ | A function that returns a set of codesandbox files, e.g. `{'index.js': {content: 'console.log("hello world")'}}`. It receives below listed data as an object.     |
 
 #### Snippet Data
 

--- a/src/CodeExporter.js
+++ b/src/CodeExporter.js
@@ -644,6 +644,7 @@ type WrapperProps = {
   onSelectSnippet?: (snippet: Snippet) => void,
   onSetOptionValue?: (snippet: Snippet, option: string, value: boolean) => void,
   optionValues?: OptionValues,
+  onGenerateCodesandbox?: ?({sandboxId: string}) => void,
 };
 
 // we borrow class names from graphiql's CSS as the visual appearance is the same
@@ -661,6 +662,7 @@ export default function CodeExporterWrapper({
   onSelectSnippet,
   onSetOptionValue,
   optionValues,
+  onGenerateCodesandbox,
 }: WrapperProps) {
   let jsonVariables: Variables = {};
 
@@ -704,6 +706,7 @@ export default function CodeExporterWrapper({
               onSelectSnippet={onSelectSnippet}
               onSetOptionValue={onSetOptionValue}
               optionValues={optionValues || {}}
+              onGenerateCodesandbox={onGenerateCodesandbox}
             />
           </ErrorBoundary>
         ) : (

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,13 @@
 // @flow
 
 import CodeExporter from './CodeExporter';
+import capitalizeFirstLetter from './utils/capitalizeFirstLetter';
+import jsCommentsFactory from './utils/jsCommentsFactory';
+import snippets from './snippets/index';
+
 export type {
+  CodesandboxFile,
+  CodesandboxFiles,
   Snippet,
   GenerateOptions,
   OperationData,
@@ -9,10 +15,6 @@ export type {
   OptionValues,
   Variables,
 } from './CodeExporter';
-
-import capitalizeFirstLetter from './utils/capitalizeFirstLetter';
-import jsCommentsFactory from './utils/jsCommentsFactory';
-import snippets from './snippets/index';
 
 export {capitalizeFirstLetter, jsCommentsFactory, snippets};
 

--- a/src/snippets/javascript/fetch.js
+++ b/src/snippets/javascript/fetch.js
@@ -3,7 +3,6 @@
 import capitalizeFirstLetter from '../../utils/capitalizeFirstLetter';
 import commentsFactory from '../../utils/jsCommentsFactory.js';
 import {
-  findFirstNamedOperation,
   isOperationNamed,
   collapseExtraNewlines,
   addLeftWhitespace,
@@ -56,10 +55,10 @@ function operationFunctionName(operationData: OperationData) {
     type === 'query'
       ? 'fetch'
       : type === 'mutation'
-        ? 'execute'
-        : type === 'subscription'
-          ? 'subscribeTo'
-          : '';
+      ? 'execute'
+      : type === 'subscription'
+      ? 'subscribeTo'
+      : '';
 
   const fnName =
     prefix +
@@ -76,10 +75,14 @@ function promiseFetcher(serverUrl: string, headers: string): string {
   return fetch(
     "${serverUrl}",
     {
-      method: "POST",${headers ? `
+      method: "POST",${
+        headers
+          ? `
       headers: {
 ${addLeftWhitespace(headers, 8)}
-      },` : ''}
+      },`
+          : ''
+      }
       body: JSON.stringify({
         query: operationsDoc,
         variables: variables,
@@ -118,13 +121,13 @@ function promiseFetcherInvocation(
   vars,
 ): string {
   return operationDataList
-    .map(namedOperationData =>  {
+    .map(namedOperationData => {
       const params = (
         namedOperationData.operationDefinition.variableDefinitions || []
       ).map(def => def.variable.name.value);
-      const variables = Object.entries(
-        namedOperationData.variables || {}
-      ).map(([key, value]) => `const ${key} = ${JSON.stringify(value, null, 2)};`);
+      const variables = Object.entries(namedOperationData.variables || {}).map(
+        ([key, value]) => `const ${key} = ${JSON.stringify(value, null, 2)};`,
+      );
       return `${variables.join('\n')}
 
 ${operationFunctionName(namedOperationData)}(${params.join(', ')})
@@ -150,10 +153,14 @@ function asyncFetcher(serverUrl: string, headers: string): string {
   const result = await fetch(
     "${serverUrl}",
     {
-      method: "POST",${headers ? `
+      method: "POST",${
+        headers
+          ? `
       headers: {
 ${addLeftWhitespace(headers, 8)}
-      },` : ''}
+      },`
+          : ''
+      }
       body: JSON.stringify({
         query: operationsDoc,
         variables: variables,
@@ -172,16 +179,16 @@ function asyncFetcherInvocation(
   vars,
 ): string {
   return operationDataList
-    .map(namedOperationData =>  {
+    .map(namedOperationData => {
       const params = (
         namedOperationData.operationDefinition.variableDefinitions || []
       ).map(def => def.variable.name.value);
-      const variables = Object.entries(
-        namedOperationData.variables || {}
-      ).map(([key, value]) => `const ${key} = ${JSON.stringify(value, null, 2)};`);
-      return `async function start${capitalizeFirstLetter(operationFunctionName(
-        namedOperationData,
-      ))}(${params.join(', ')}) {
+      const variables = Object.entries(namedOperationData.variables || {}).map(
+        ([key, value]) => `const ${key} = ${JSON.stringify(value, null, 2)};`,
+      );
+      return `async function start${capitalizeFirstLetter(
+        operationFunctionName(namedOperationData),
+      )}(${params.join(', ')}) {
   const { errors, data } = await ${operationFunctionName(
     namedOperationData,
   )}(${params.join(', ')});
@@ -197,9 +204,9 @@ function asyncFetcherInvocation(
 
 ${variables.join('\n')}
 
-start${capitalizeFirstLetter(operationFunctionName(
-  namedOperationData,
-))}(${params.join(', ')});`;
+start${capitalizeFirstLetter(
+        operationFunctionName(namedOperationData),
+      )}(${params.join(', ')});`;
     })
     .join('\n\n');
 }
@@ -237,9 +244,6 @@ ${operationData.type} unnamed${capitalizeFirstLetter(operationData.type)}${idx +
       },
     );
 
-    const namedOperation =
-      findFirstNamedOperation(opts.operationDataList) || operationDataList[0];
-
     const getComment = commentsFactory(true, comments);
 
     const serverComment = options.server ? getComment('nodeFetch') : '';
@@ -250,9 +254,9 @@ ${operationData.type} unnamed${capitalizeFirstLetter(operationData.type)}${idx +
     const graphqlQuery = generateDocumentQuery(operationDataList);
     const vars = JSON.stringify({}, null, 2);
     const headersValues = [];
-    for (const k of Object.keys(headers)) {
-      if (k && headers[k]) {
-        headersValues.push(`"${k}": "${headers[k]}"`);
+    for (const header of Object.keys(headers)) {
+      if (header && headers[header]) {
+        headersValues.push(`"${header}": "${headers[header]}"`);
       }
     }
     const heads = headersValues.length ? `${headersValues.join(',\n')}` : '';

--- a/src/snippets/javascript/reactApollo.js
+++ b/src/snippets/javascript/reactApollo.js
@@ -40,7 +40,9 @@ function operationVariables(operationData: OperationData) {
   const variablesBody = params.map(param => `"${param}": ${param}`).join(', ');
   const variables = `{${variablesBody}}`;
 
-  const propsBody = params.map(param => `"${param}": props.${param}`).join(', ');
+  const propsBody = params
+    .map(param => `"${param}": props.${param}`)
+    .join(', ');
   const props = `{${propsBody}}`;
 
   return {params, variables, props};
@@ -53,10 +55,10 @@ function operationComponentName(operationData: OperationData): string {
     type === 'query'
       ? 'Query'
       : type === 'mutation'
-        ? 'Mutation'
-        : type === 'subscription'
-          ? 'Subscription'
-          : '';
+      ? 'Mutation'
+      : type === 'subscription'
+      ? 'Subscription'
+      : '';
 
   return suffix.length > 0
     ? '' + capitalizeFirstLetter(operationData.name) + suffix
@@ -262,11 +264,11 @@ ${reactApolloImports}`
           operationData.type === 'query'
             ? queryComponent
             : operationData.type === 'mutation'
-              ? mutationComponent
-              : () =>
-                  `"We don't support ${
-                    operationData.type
-                  } GraphQL operations yet"`;
+            ? mutationComponent
+            : () =>
+                `"We don't support ${
+                  operationData.type
+                } GraphQL operations yet"`;
 
         const graphqlOperation = `const ${operationVariableName(
           operationData,
@@ -279,17 +281,17 @@ ${addLeftWhitespace(operationData.query, 2)}
 const ${operationComponentName(operationData)} = (props) => {
   return (
 ${addLeftWhitespace(
-          componentFn(
-            // $FlowFixMe: Add flow type to utils fn
-            getComment,
-            options,
-            element,
-            operationData,
-            heads,
-            vars,
-          ),
-          4,
-        )}
+  componentFn(
+    // $FlowFixMe: Add flow type to utils fn
+    getComment,
+    options,
+    element,
+    operationData,
+    heads,
+    vars,
+  ),
+  4,
+)}
   )
 };`;
 
@@ -309,9 +311,9 @@ ${addLeftWhitespace(
 
     const variableInstantiations = operationDataList
       .map(operationData => {
-        const variables = Object.entries(
-          operationData.variables || {}
-        ).map(([key, value]) => `const ${key} = ${JSON.stringify(value, null, 2)};`);
+        const variables = Object.entries(operationData.variables || {}).map(
+          ([key, value]) => `const ${key} = ${JSON.stringify(value, null, 2)};`,
+        );
 
         return `${variables.join('\n')}`;
       })


### PR DESCRIPTION
Allows snippets to define a `generateCodesandboxFiles` function that will be used to create a CodeSandbox. The new function takes the same arguments as the `generate` function.

If the snippet defines `generateCodesandboxFiles` and there is a valid query, we'll show a "Create CodeSandbox" button. Clicking that will generate the sandbox and display a link to access it.

Users of the library can supply a `onGenerateCodesandbox` prop to do additional things with the sandbox that was generated (e.g. programmatically add cors origins for the codesandbox origin).

![image](https://user-images.githubusercontent.com/476818/67727381-78516b80-f9a6-11e9-86c9-0d377591b4eb.png)

![image](https://user-images.githubusercontent.com/476818/67727397-83a49700-f9a6-11e9-9c75-f584c84c71fa.png)
