### PR TITLE
Subscriptions enabled

### DIFF
--- a/src/CodeExporter.js
+++ b/src/CodeExporter.js
@@ -4,12 +4,14 @@ import copy from 'copy-to-clipboard';
 import {parse, print} from 'graphql';
 // $FlowFixMe: can't find module
 import CodeMirror from 'codemirror';
+import toposort from './toposort.js';
 
 import type {
   FragmentDefinitionNode,
   OperationDefinitionNode,
   VariableDefinitionNode,
   OperationTypeNode,
+  SelectionSetNode,
   Schema,
 } from 'graphql';
 
@@ -68,6 +70,7 @@ export type OperationData = {
   variableName: string,
   variables: Variables,
   operationDefinition: OperationDefinitionNode,
+  fragmentDependencies: Array<FragmentDefinitionNode>,
 };
 
 export type GenerateOptions = {
@@ -116,6 +119,53 @@ async function createCodesandbox(
     return {sandboxId: json.sandbox_id};
   }
 }
+
+let findFragmentDependencies = (
+  operationDefinitions: Array<FragmentDefinitionNode>,
+  def: OperationDefinitionNode | FragmentDefinitionNode,
+): Array<FragmentDefinitionNode> => {
+  const fragmentByName = (name: string) => {
+    return operationDefinitions.find(def => def.name.value === name);
+  };
+
+  const findReferencedFragments = (
+    selectionSet: SelectionSetNode,
+  ): Array<FragmentDefinitionNode> => {
+    const selections = selectionSet.selections;
+
+    const namedFragments = selections
+      .map(selection => {
+        if (selection.kind === 'FragmentSpread') {
+          return fragmentByName(selection.name.value);
+        } else {
+          return null;
+        }
+      })
+      .filter(Boolean);
+
+    const nestedNamedFragments: Array<FragmentDefinitionNode> = selections.reduce(
+      (acc, selection) => {
+        if (
+          (selection.kind === 'Field' ||
+            selection.kind === 'SelectionNode' ||
+            selection.kind === 'InlineFragment') &&
+          selection.selectionSet !== undefined
+        ) {
+          return acc.concat(findReferencedFragments(selection.selectionSet));
+        } else {
+          return acc;
+        }
+      },
+      [],
+    );
+
+    return namedFragments.concat(nestedNamedFragments);
+  };
+
+  const selectionSet = def.selectionSet;
+
+  return findReferencedFragments(selectionSet);
+};
 
 let operationNodesMemo: [
   ?string,
@@ -416,7 +466,15 @@ class CodeExporter extends Component<Props, State> {
 
     const {name, language, generate} = snippet;
 
-    const operationDataList: Array<OperationData> = operationDefinitions.map(
+    const fragmentDefinitions: Array<FragmentDefinitionNode> = [];
+
+    for (const operationDefinition of operationDefinitions) {
+      if (operationDefinition.kind === 'FragmentDefinition') {
+        fragmentDefinitions.push(operationDefinition);
+      }
+    }
+
+    const rawOperationDataList: Array<OperationData> = operationDefinitions.map(
       (
         operationDefinition: OperationDefinitionNode | FragmentDefinitionNode,
       ) => ({
@@ -427,12 +485,16 @@ class CodeExporter extends Component<Props, State> {
         variableName: formatVariableName(getOperationName(operationDefinition)),
         variables: getUsedVariables(variables, operationDefinition),
         operationDefinition,
+        fragmentDependencies: findFragmentDependencies(
+          fragmentDefinitions,
+          operationDefinition,
+        ),
       }),
     );
 
-    window.myODs = operationDataList;
+    const operationDataList = toposort(rawOperationDataList);
 
-    const optionValues = this.getOptionValues(snippet);
+    const optionValues: Array<OperationData> = this.getOptionValues(snippet);
 
     const codeSnippet = operationDefinitions.length
       ? generate(

--- a/src/toposort.js
+++ b/src/toposort.js
@@ -1,0 +1,63 @@
+// @flow
+import type {FragmentDefinitionNode, OperationDefinitionNode} from 'graphql';
+import type {OperationData} from './CodeExporter.js';
+
+type stringBoolMap = {[string]: boolean};
+
+const operationDataByName = (
+  graph: Array<OperationData>,
+  name: string,
+): ?OperationData => {
+  return graph.find(operationData => operationData.name === name);
+};
+
+function topologicalSortHelper(
+  node: OperationData,
+  visited: stringBoolMap,
+  temp: stringBoolMap,
+  graph: Array<OperationData>,
+  result,
+) {
+  temp[node.name] = true;
+  var neighbors = node.fragmentDependencies;
+  for (var i = 0; i < neighbors.length; i += 1) {
+    var fragmentDependency = neighbors[i];
+    var fragmentOperationData = operationDataByName(
+      graph,
+      fragmentDependency.name.value,
+    );
+
+    if (!fragmentOperationData) {
+      continue;
+    }
+
+    if (temp[fragmentOperationData.name]) {
+      console.error('The operation graph has a cycle');
+      continue;
+    }
+    if (!visited[fragmentOperationData.name]) {
+      topologicalSortHelper(
+        fragmentOperationData,
+        visited,
+        temp,
+        graph,
+        result,
+      );
+    }
+  }
+  temp[node.name] = false;
+  visited[node.name] = true;
+  result.push(node);
+}
+
+export default function toposort(graph: Array<OperationData>) {
+  var result: Array<OperationData> = [];
+  var visited = {};
+  var temp = {};
+  for (var node of graph) {
+    if (!visited[node.name] && !temp[node.name]) {
+      topologicalSortHelper(node, visited, temp, graph, result);
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
1. Enables subscriptions in snippets
2. Passes in the schema in case there are type-specific changes that need to happen in the code generation (relevant some times for typed languages or form generation)
3. Topologically sorts the operations so that snippets can generate code by simply mapping over the operations without worrying about previous definitions.