### PR TITLE
Allow a pre-hook for CodeSandbox generation

### DIFF
--- a/src/toposort.js
+++ b/src/toposort.js
@@ -1,5 +1,4 @@
 // @flow
-import type {FragmentDefinitionNode, OperationDefinitionNode} from 'graphql';
 import type {OperationData} from './CodeExporter.js';
 
 type stringBoolMap = {[string]: boolean};


### PR DESCRIPTION
Also switches to a class for the wrapper so there's a ref for programmatic CSB generation, and adds, a bit of extra configurability for the CSB button text